### PR TITLE
Reversing order of permutations

### DIFF
--- a/dat/util.py
+++ b/dat/util.py
@@ -77,7 +77,7 @@ def lookup_ingredient(vocab, ingredient):
       return split[0]
     else:
       full = []
-      for i in range(1, len(split)):
+      for i in range(len(split) - 1, 0, -1):
         for permutation in itertools.permutations(split, i):
           full.append('_'.join(permutation))
       match = next((perm for perm in full if perm in vocab), None)


### PR DESCRIPTION
One problem I've when running the vocab extraction is that the shortest permutation of a word is matched in the `lookup_ingredient` function.  This means that `soda` matches instead of `baking_soda` or `vegetable` matches instead of `vegetable_oil`.  This seems undesirable.  By switching the order of the permutations to generate the longest permutations first, the longest permutation will match first.

I can see other cases where this would be undesirable (`sea_salt` matching instead of just `salt`), but that could possibly be helped by building out the blacklist more thoroughly.  What do you think?